### PR TITLE
Add location from ways and relations

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ To install this script:
 1. [Click here](https://github.com/meitar/osm2vcf/raw/master/osm2vcf.user.js).
 1. Confirm the installation, usually by pressing the "`Allow`," "`Install`," or "`OK`" button in the dialogue window that opens.
 
-To use this script, navigate to any [node](https://wiki.openstreetmap.org/wiki/Node) or [way](https://wiki.openstreetmap.org/wiki/Way) on OpenStreetMap's Web interface.
+To use this script, navigate to any [node](https://wiki.openstreetmap.org/wiki/Node), [way](https://wiki.openstreetmap.org/wiki/Way) or [relation](https://wiki.openstreetmap.org/wiki/Relation) on OpenStreetMap's Web interface.

--- a/osm2vcf.user.js
+++ b/osm2vcf.user.js
@@ -86,28 +86,10 @@ function parseApiResponse (response) {
         }
     }
 
-    // Only OSM Nodes have individual lat/lon info.
-    if (el.getAttribute('lat') && el.getAttribute('lon')) {
-        var keys = ['lat', 'lon'];
-        for (var i = 0; i < keys.length; i++) {
-            r[keys[i]] = el.getAttribute(keys[i]);
-        }
-        return r; // We've got an OSM Node, nothing more to do.
-    }
-
-    // Relations will have member Ways, from which we choose one.
-    var way = ('way' === el.tagName)
-        ? el // The requested object is a Way. Use it.
-        : d.querySelector( // Find the first member Way and use it.
-            '[id="' + el.querySelector('member[type="way"]').getAttribute('ref') + '"]'
-        );
-
-    // On the other hand, Ways will contain a list of member nodes.
     r['x-osm-member-nodes'] = [];
-    Array.from(way.querySelectorAll('nd[ref]')).map(function (x) {
-        return x.getAttribute('ref');
-    }).forEach(function (id) {
-        r['x-osm-member-nodes'].push(d.querySelector('[id="' + id + '"]'));
+    Array.from(d.querySelectorAll('node'))
+      .forEach(function (node) {
+        r['x-osm-member-nodes'].push(node);
     });
 
     return r;
@@ -126,10 +108,6 @@ function parseApiResponse (response) {
  * @return {object} OSM-formatted object with guaranteed lat/lon.
  */
 function normalizeGeographicCenter (osm) {
-    if (osm.lat && osm.lon) {
-        return osm; // We already have a location.
-    }
-
     // We need to find the geographic center from the member nodes.
     var points = osm['x-osm-member-nodes'].map(function (el) {
         return {

--- a/osm2vcf.user.js
+++ b/osm2vcf.user.js
@@ -10,6 +10,8 @@
 // @include     https://www.openstreetmap.org/way/*
 // @version     1.1.2
 // @updateURL   https://github.com/meitar/osm2vcf/raw/master/osm2vcf.user.js
+// @include     https://www.openstreetmap.org/relation/*
+// @version     1.2.0
 // @grant       GM.xmlHttpRequest
 // ==/UserScript==
 
@@ -46,6 +48,60 @@ function init () {
     CONFIG.api_anchor.insertAdjacentHTML('afterend', ' · ');
 }
 
+/** Put the content on the link */
+function setContent(content) {
+            var b = new Blob([
+                vCardWriter(osm2vcf(content))
+            ], { 'type': 'text/vcard' });
+            CONFIG.download_button.setAttribute('href', URL.createObjectURL(b));
+            window.location = CONFIG.download_button.getAttribute('href');
+}
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/** Set the output location to be roughly the middle of the locations of all the nodes */
+async function addLocationFromNodes (elementWithNodes, responseStructure) {
+  let minLat = 180.0;
+  let maxLat = -180.0;
+  let minLon = 180.0;
+  let maxLon = -180.0;
+	let count = 0.0;
+	let allNodes = elementWithNodes.querySelectorAll('nd');
+  for(var n = 0; n < allNodes.length; n++) {
+    let nd = allNodes[n];
+		let baseUrl = window.location.protocol + '//' + window.location.host +
+                					CONFIG.api_url.substring(0, CONFIG.api_url.indexOf(CONFIG.api_url.match(/relation|way/)[0]));
+		let ndUrl = baseUrl + 'node/' + nd.getAttribute('ref');
+		GM.xmlHttpRequest({
+			'method': 'GET',
+			'synchronous': true,
+			'url': ndUrl,
+			'onload': function (wayResponse) {
+        var ndDom = wayResponse.responseXML.documentElement;
+        count += 1;
+        if (ndDom.querySelector('node')) {
+          var keys = ['lat', 'lon'];
+          let lat = parseFloat(ndDom.querySelector('node').getAttribute('lat'));
+          let lon = parseFloat(ndDom.querySelector('node').getAttribute('lon'));
+          if (lat < minLat) minLat = lat;
+          if (lat > maxLat) maxLat = lat;
+          if (lon < minLon) minLon = lon;
+          if (lon > maxLon) maxLon = lon;
+        }
+			}
+		});
+	}
+  while (count < allNodes.length) {
+    await sleep(100);
+  }
+	responseStructure['lat'] = ((minLat + maxLat) / 2).toFixed(7);
+	responseStructure['lon'] = ((minLon + maxLon) / 2).toFixed(7);
+	setContent(responseStructure);
+}
+
+
 /**
  * Receives the XMLHttpRequest response from the OSM API server.
  *
@@ -58,6 +114,7 @@ function parseApiResponse (response) {
     var el = response.responseXML.documentElement;
     var keys = [
         'addr:city',
+        'addr:place',
         'addr:housenumber',
         'addr:postcode',
         'addr:state',
@@ -84,8 +141,27 @@ function parseApiResponse (response) {
             r[keys[i]] = el.querySelector('node')
                 .getAttribute(keys[i]);
         }
+  	setContent(r);
+    } else {
+      	// If we have something with ways, pick the first way and set the location based on its centre
+      	if (el.querySelector('member[type="way"]')) {
+            let baseUrl = window.location.protocol + '//' + window.location.host +
+                					CONFIG.api_url.substring(0,
+                                       CONFIG.api_url.indexOf(CONFIG.api_url.match(/relation|way/)[0]));
+            let wayUrl = baseUrl + 'way/' + el.querySelector('member[type="way"]').getAttribute('ref');
+            GM.xmlHttpRequest({
+			        'method': 'GET',
+              'synchronous': true,
+        			'url': wayUrl,
+        			'onload': function (wayResponse) {
+            		addLocationFromNodes(wayResponse.responseXML.documentElement, r);
+			        }
+    				});
+        } else {
+          // If we have something with nodes, set the location based on the centre of the nodes
+         addLocationFromNodes(el, r);
+        }
     }
-    return r;
 }
 
 /**
@@ -108,7 +184,7 @@ function osm2vcf (osm) {
             '',
             osm['addr:housenumber'] || '',
             osm['addr:street'] || '',
-            osm['addr:city'] || '',
+            osm['addr:city'] || osm['addr:place'] || '',
             osm['addr:state'] || '',
             osm['addr:postcode'] || '',
             osm['addr:country'] || ''
@@ -194,11 +270,7 @@ function main (e) {
         'synchronous': true,
         'url': window.location.protocol + '//' + window.location.host + CONFIG.api_url,
         'onload': function (response) {
-            var b = new Blob([
-                vCardWriter(osm2vcf(parseApiResponse(response)))
-            ], { 'type': 'text/vcard' });
-            CONFIG.download_button.setAttribute('href', URL.createObjectURL(b));
-            window.location = CONFIG.download_button.getAttribute('href');
+          parseApiResponse(response);
         }
     });
 }

--- a/osm2vcf.user.js
+++ b/osm2vcf.user.js
@@ -87,6 +87,19 @@ function parseApiResponse (response) {
     }
 
     r['x-osm-member-nodes'] = [];
+
+    // A relation may just be a collection of ways
+    // but some towns and cities have a node that is its centre.
+    // This is more meaningful than using the middle of the boundary.
+    if ('relation' === el.tagName) {
+        let nodes = el.querySelectorAll('member[type="node"]');
+        if (nodes.length == 1) {
+            r['x-osm-member-nodes'].push(d.querySelector('[id="' + nodes[0].getAttribute('ref') + '"'));
+            return r;
+        }
+    }
+
+    // otherwise add all nodes in the hierarchy to calculate the middle
     Array.from(d.querySelectorAll('node'))
       .forEach(function (node) {
         r['x-osm-member-nodes'].push(node);


### PR DESCRIPTION
osm2vcf is really useful for creating destinations to add to in-car navigation systems like the RNS510 used in Volkswagen cars (see https://forums.vwvortex.com/showthread.php?5187281-quot-Volkswagen-Nav-Companion-quot for how that works).

I tried it out, and whilst it provides the location information for nodes, a lot of landmarks and buildings are represented as ways or even relations, and without the location information you can't use the VCFs to navigate.

This PR adds the ability to traverse from relations and ways down to individual nodes and create a crude midpoint location that will allow navigation.

I have tried it out and it works well, even on relatively large relations (66 nodes was no problem).  However, I am not a Javascript developer (I usually work with Java) so my code may not be great, and I am also not a Greasemonkey expert - I only installed it yesterday to make use of osm2vcf.